### PR TITLE
Update schema

### DIFF
--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -1,0 +1,2 @@
+class Currency < ApplicationRecord
+end

--- a/db/migrate/20200330101635_create_currencies.rb
+++ b/db/migrate/20200330101635_create_currencies.rb
@@ -1,0 +1,11 @@
+class CreateCurrencies < ActiveRecord::Migration[6.0]
+  def change
+    create_table :currencies do |t|
+      t.datetime :published_at
+      t.string :source
+      t.json :target_rates
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_06_100346) do
+ActiveRecord::Schema.define(version: 2020_03_30_101635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "currencies", force: :cascade do |t|
+    t.datetime "published_at"
+    t.string "source"
+    t.json "target_rates"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "departments", force: :cascade do |t|
     t.string "name"

--- a/spec/factories/currencies.rb
+++ b/spec/factories/currencies.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :currency do
+    published_at { DateTime.current }
+    source { 'EUR' }
+    target_rates { [{ 'target' => 'USD', 'rate' => 1.0977 },
+                    { 'target' => 'CHF', 'rate' => 1.0581 }] }
+
+    trait :for_usd_dollar do
+      source { 'USD' }
+      target_rates { [{ 'target' => 'EUR', 'rate' => 0.895375 },
+                      { 'target' => 'CHF', 'rate' => 0.951265 }] }
+    end
+  end
+end

--- a/spec/models/currency_spec.rb
+++ b/spec/models/currency_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Currency, type: :model do
+  let(:attributes) { attributes_for(:currency) }
+
+  describe '.create' do
+    subject(:create) { described_class.create(attributes) }
+
+    it 'creates an entry for a currency' do
+      expect { create }.to change { described_class.count }.from(0).to(1)
+    end
+  end
+
+  describe '#target_rates' do
+    subject(:target_rates) { currency.target_rates }
+    let(:currency) { described_class.create(attributes) }
+
+    it { is_expected.to eq(attributes[:target_rates]) }
+  end
+end

--- a/spec/models/department_spec.rb
+++ b/spec/models/department_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Department, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Employee, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
Adds model `currency` to schema

### What is good for

Adding the schema so that the values can be synced with`https://currencylayer.com/` (or `https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html`)