### PR TITLE
Refactor currency model attributes

### DIFF
--- a/app/controllers/currencies_controller.rb
+++ b/app/controllers/currencies_controller.rb
@@ -27,7 +27,7 @@ class CurrenciesController < ApplicationController
   end
 
   def foreign_rates
-    currency.target_rates
+    currency.target_rates || currency.foreign_rates
   end
 
   def foreign_currency

--- a/app/graphql/types/currency_type.rb
+++ b/app/graphql/types/currency_type.rb
@@ -1,12 +1,26 @@
 module Types
   class CurrencyType < Types::BaseObject
     field :id, ID, 'The unique id of the currency entry', null: false
-    field :source, String, 'The source label of the currency', null: false
+    field :source,
+          String,
+          'The source label of the currency',
+          null: true,
+          deprecation_reason: 'Will be removed, use base instead!'
+    field :base,
+           String,
+           'The base currency that this entry relates to',
+           null: false
     field :targetRates,
           [TargetRateType, null: true],
           'A list of currency target rates relating to the source',
           null: true,
-          method: :target_rates
+          method: :target_rates,
+          deprecation_reason: 'Will be removed, use foreignRates instead!'
+    field :foreignRates,
+          [ForeignRateType, null: true],
+          'A list containing foreign rates for base currency',
+          null: true,
+          method: :foreign_rates
     field :publishedAt,
           GraphQL::Types::ISO8601DateTime,
           'The iso8601 datetime the targetRates for the source currency '\

--- a/app/graphql/types/foreign_rate_type.rb
+++ b/app/graphql/types/foreign_rate_type.rb
@@ -1,0 +1,6 @@
+module Types
+  class ForeignRateType < Types::BaseObject
+    field :currency, String, 'The currency label', null: false
+    field :rate, Float, 'The current rate for the currency', null: false
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -12,6 +12,7 @@ module Types
 
     field :currencies, [CurrencyType], 'Query for currencies', null: true do
       argument :source, [String], required: false
+      argument :base, [String], required: false
       argument :publishedAtFrom,
                 GraphQL::Types::ISO8601DateTime,
                 required: false,

--- a/app/service/currency_exchanger.rb
+++ b/app/service/currency_exchanger.rb
@@ -20,7 +20,9 @@ class CurrencyExchanger
   end
 
   def rate_for(currency)
-    (@foreign_rates.find{ |entry| entry['target'] == currency } || {})['rate']
+    (@foreign_rates.find do |entry|
+      entry['target'] == currency || entry['currency'] == currency
+    end || {})['rate']
   end
 
   def inverse_rate
@@ -40,7 +42,8 @@ class CurrencyExchanger
   end
 
   def foreign_currencies
-    @foreign_currencies ||=
-      @foreign_rates.map { |foreign_rate| foreign_rate['target'] }
+    @foreign_currencies ||= @foreign_rates.map do |foreign_rate|
+      foreign_rate['target'] || foreign_rate['currency']
+    end
   end
 end

--- a/app/service/currencylayer/rating_quotes.rb
+++ b/app/service/currencylayer/rating_quotes.rb
@@ -1,25 +1,16 @@
 module Currencylayer
   class RatingQuotes
-    def initialize(source, update_rates, published_at, target_currencies)
-      @source = source
-      @update_rates = update_rates
+    def initialize(base, foreign_rates_update, published_at)
+      @base = base
+      @foreign_rates_update = foreign_rates_update
       @published_at = published_at
-      @target_currencies = target_currencies
     end
 
     def upsert
-      target_rates = @update_rates.select { |entry| relevant_country?(entry) }
-
-      entry = Currency.find_or_initialize_by(source: @source,
-                                             published_at: @published_at)
-      entry.target_rates = target_rates
+      entry =
+        Currency.find_or_initialize_by(base: @base, published_at: @published_at)
+      entry.foreign_rates = @foreign_rates_update
       entry.save
-    end
-
-    private
-
-    def relevant_country?(entry)
-      @target_currencies.include?(entry.fetch('target'))
     end
   end
 end

--- a/db/migrate/20200405093309_add_base_to_currencies.rb
+++ b/db/migrate/20200405093309_add_base_to_currencies.rb
@@ -1,0 +1,5 @@
+class AddBaseToCurrencies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :currencies, :base, :string, null: false, default: ''
+  end
+end

--- a/db/migrate/20200405093449_add_foreign_rates_to_currencies.rb
+++ b/db/migrate/20200405093449_add_foreign_rates_to_currencies.rb
@@ -1,0 +1,5 @@
+class AddForeignRatesToCurrencies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :currencies, :foreign_rates, :json, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_101635) do
+ActiveRecord::Schema.define(version: 2020_04_05_093449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2020_03_30_101635) do
     t.json "target_rates"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "base", default: "", null: false
+    t.json "foreign_rates", default: [], null: false
   end
 
   create_table "departments", force: :cascade do |t|

--- a/lib/tasks/currencylayer_import.rake
+++ b/lib/tasks/currencylayer_import.rake
@@ -5,10 +5,9 @@ namespace :currencylayer_import do
     bank.expire_rates! if bank.expired?
     restructured_rates =
       Currencylayer::TargetRatesPresenter.new(bank.update_rates).restructure
-    target_currencies = Rails.application.config.currencylayer.currencies
     Currencylayer::RatingQuotes.new(bank.source,
                                     restructured_rates,
-                                    bank.rates_timestamp,
-                                    target_currencies).upsert
+                                    bank.rates_timestamp)
+                                .upsert
   end
 end

--- a/lib/tasks/one_time_tasks.rake
+++ b/lib/tasks/one_time_tasks.rake
@@ -1,0 +1,16 @@
+namespace :one_time_tasks do
+  desc "Currency data migration for updated schema"
+  task currency_data_migration: :environment do
+    Currency.where(base: '').find_in_batches do |currencies|
+      currencies.each do |currency|
+        currency.base = currency.source
+        foreign_rates = currency.target_rates.map do |target_rates|
+          { 'currency' => target_rates['target'],
+            'rate' => target_rates['rate'] }
+        end
+        currency.foreign_rates = foreign_rates
+        currency.save
+      end
+    end
+  end
+end

--- a/spec/controllers/currencies_controller_spec.rb
+++ b/spec/controllers/currencies_controller_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe CurrenciesController, type: :controller do
         currency: { base: base, value: value, foreign: foreign }
       }
     end
-    let(:base) { currency.source }
+    let(:base) { currency.base }
     let(:value) { 1.0 }
-    let(:foreign) { currency.target_rates.sample['target'] }
+    let(:foreign) { currency.foreign_rates.sample['currency'] }
 
     let(:currency_exchanger) do
       instance_double(CurrencyExchanger, foreign_rate_for: 1)
@@ -65,7 +65,7 @@ RSpec.describe CurrenciesController, type: :controller do
 
     it 'initializes service class with source and target_rates' do
       expect(CurrencyExchanger).to receive(:new)
-        .with(base, currency.target_rates)
+        .with(base, currency.foreign_rates)
         .and_call_original
 
       get :exchange, xhr: true, params: exchange_params

--- a/spec/factories/currencies.rb
+++ b/spec/factories/currencies.rb
@@ -1,19 +1,25 @@
 FactoryBot.define do
   factory :currency do
     published_at { DateTime.current }
-    source { 'EUR' }
-    target_rates { [{ 'target' => 'USD', 'rate' => 1.0977 },
-                    { 'target' => 'CHF', 'rate' => 1.0581 }] }
+    base { 'EUR' }
+    foreign_rates {
+      [{ 'currency' => 'USD', 'rate' => 1.0977 },
+       { 'currency' => 'CHF', 'rate' => 1.0581 }]
+     }
 
     trait :for_usd_dollar do
-      source { 'USD' }
-      target_rates { [{ 'target' => 'EUR', 'rate' => 0.895375 },
-                      { 'target' => 'CHF', 'rate' => 0.951265 }] }
+      base { 'USD' }
+      foreign_rates {
+        [{ 'currency' => 'EUR', 'rate' => 0.895375 },
+         { 'currency' => 'CHF', 'rate' => 0.951265 }]
+       }
     end
 
     trait :with_random_target_rates do
-      target_rates { [{ 'target' => 'USD', 'rate' => Random.rand(1.0..1.2) },
-                      { 'target' => 'CHF', 'rate' => Random.rand(1.2..1.4) }] }
+      target_rates {
+        [{ 'currency' => 'USD', 'rate' => Random.rand(1.0..1.2) },
+         { 'currency' => 'CHF', 'rate' => Random.rand(1.2..1.4) }]
+       }
     end
   end
 end

--- a/spec/factories/currencies.rb
+++ b/spec/factories/currencies.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     end
 
     trait :with_random_target_rates do
-      target_rates {
+      foreign_rates {
         [{ 'currency' => 'USD', 'rate' => Random.rand(1.0..1.2) },
          { 'currency' => 'CHF', 'rate' => Random.rand(1.2..1.4) }]
        }

--- a/spec/graphql/schema_spec.rb
+++ b/spec/graphql/schema_spec.rb
@@ -58,17 +58,17 @@ RSpec.describe GraphqlServerSchema do
     context 'when querying for currency' do
       let(:query_type) { 'currencies' }
       let(:query_conditions) do
-        "source: [\"#{currency.source}\"],
+        "base: [\"#{currency.base}\"],
          publishedAtFrom: \"#{(currency.published_at - 1.day).iso8601}\",
          publishedAtTo: \"#{(currency.published_at + 1.day).iso8601}\""
       end
-      let(:query_return_fields) { 'id source publishedAt' }
+      let(:query_return_fields) { 'id base publishedAt' }
 
       let(:currency) { create(:currency) }
       let(:response_hash) do
         {
           'id' => currency.id.to_s,
-          'source' => currency.source,
+          'base' => currency.base,
           'publishedAt' => currency.published_at.iso8601
         }
       end
@@ -77,19 +77,19 @@ RSpec.describe GraphqlServerSchema do
 
       context 'with targetRates' do
         let(:query_return_fields) do
-          'id source publishedAt targetRates { currency rate }'
+          'id base publishedAt foreignRates { currency rate }'
         end
         let(:response_hash) do
           {
             'id' => currency.id.to_s,
-            'source' => currency.source,
+            'base' => currency.base,
             'publishedAt' => currency.published_at.iso8601,
-            'targetRates' => target_rates.map do |entry|
-              { 'currency' => entry['target'], 'rate' => entry['rate'] }
+            'foreignRates' => foreign_rates.map do |entry|
+              { 'currency' => entry['currency'], 'rate' => entry['rate'] }
             end
           }
         end
-        let(:target_rates) { currency.target_rates }
+        let(:foreign_rates) { currency.foreign_rates }
 
         it { is_expected.to eq([response_hash]) }
       end


### PR DESCRIPTION
### What is good for

Adds `base` and `foreign_rates` as substitutions for `source` and `target_rates`. This will improve readability of the currency through the whole process