### PR TITLE
Remove outdated currency attributes

### DIFF
--- a/app/controllers/currencies_controller.rb
+++ b/app/controllers/currencies_controller.rb
@@ -27,7 +27,7 @@ class CurrenciesController < ApplicationController
   end
 
   def foreign_rates
-    currency.target_rates || currency.foreign_rates
+    currency.foreign_rates
   end
 
   def foreign_currency

--- a/app/graphql/types/currency_type.rb
+++ b/app/graphql/types/currency_type.rb
@@ -1,21 +1,10 @@
 module Types
   class CurrencyType < Types::BaseObject
     field :id, ID, 'The unique id of the currency entry', null: false
-    field :source,
-          String,
-          'The source label of the currency',
-          null: true,
-          deprecation_reason: 'Will be removed, use base instead!'
     field :base,
            String,
            'The base currency that this entry relates to',
            null: false
-    field :targetRates,
-          [TargetRateType, null: true],
-          'A list of currency target rates relating to the source',
-          null: true,
-          method: :target_rates,
-          deprecation_reason: 'Will be removed, use foreignRates instead!'
     field :foreignRates,
           [ForeignRateType, null: true],
           'A list containing foreign rates for base currency',
@@ -23,7 +12,7 @@ module Types
           method: :foreign_rates
     field :publishedAt,
           GraphQL::Types::ISO8601DateTime,
-          'The iso8601 datetime the targetRates for the source currency '\
+          'The iso8601 datetime the targetRates for the base currency '\
           'belongs to',
           null: false,
           method: :published_at

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,7 +11,6 @@ module Types
     end
 
     field :currencies, [CurrencyType], 'Query for currencies', null: true do
-      argument :source, [String], required: false
       argument :base, [String], required: false
       argument :publishedAtFrom,
                 GraphQL::Types::ISO8601DateTime,

--- a/app/graphql/types/target_rate_type.rb
+++ b/app/graphql/types/target_rate_type.rb
@@ -1,6 +1,0 @@
-module Types
-  class TargetRateType < Types::BaseObject
-    field :currency, String, 'The currency label', null: false, method: :target
-    field :rate, Float, 'The current rate for the currency', null: false
-  end
-end

--- a/app/helpers/currency_helper.rb
+++ b/app/helpers/currency_helper.rb
@@ -1,6 +1,7 @@
 module CurrencyHelper
   def available_options(currency)
-    [ [currency.source, currency.source] ] |
-      currency.target_rates.map { |entry| [ entry['target'], entry['target'] ] }
+    [ [currency.base, currency.base] ] | currency.foreign_rates.map do |entry|
+      [ entry['currency'], entry['currency'] ]
+    end
   end
 end

--- a/app/javascript/packs/currency.coffee
+++ b/app/javascript/packs/currency.coffee
@@ -3,9 +3,9 @@ class CurrencyHistory
                            $publishedAtTo: ISO8601DateTime) {
                              currencies(publishedAtFrom: $publishedAtFrom,
                                         publishedAtTo: $publishedAtTo) {
-                                          source
+                                          base
                                           publishedAt
-                                          targetRates { currency rate }
+                                          foreignRates { currency rate }
                              }
                             }'
 
@@ -18,19 +18,19 @@ class CurrencyHistory
   @normalized_highchart_data: (currencies) =>
     highchart_data = {}
     for currency in currencies
-      highchart_item = @upsert_higchart_item(highchart_data, currency.source)
+      highchart_item = @upsert_higchart_item(highchart_data, currency.base)
       highchart_item['categories'].push(currency.publishedAt)
 
-      for target_rates in currency.targetRates
-        series = @upsert_highchart_series(highchart_item, target_rates.currency)
-        series.push(target_rates.rate)
+      for foreign_rate in currency.foreignRates
+        series = @upsert_highchart_series(highchart_item, foreign_rate.currency)
+        series.push(foreign_rate.rate)
 
     highchart_data
 
-  @upsert_higchart_item: (highchart_data, source) =>
-      if not highchart_data["#{source}"]?
-        highchart_data["#{source}"] = { 'categories': [], 'series': {} }
-      highchart_data["#{source}"]
+  @upsert_higchart_item: (highchart_data, base) =>
+      if not highchart_data["#{base}"]?
+        highchart_data["#{base}"] = { 'categories': [], 'series': {} }
+      highchart_data["#{base}"]
 
   @upsert_highchart_series: (highchart_item, currency) =>
       series = highchart_item['series']
@@ -39,13 +39,13 @@ class CurrencyHistory
       series["#{currency}"]
 
   @build_highcharts: (highchart_data) ->
-    for source, highchart_item of highchart_data
-      chart_id = "currency_history_#{source}"
+    for base, highchart_item of highchart_data
+      chart_id = "currency_history_#{base}"
       $('#history_body').append("<div id=\"#{chart_id}\">")
       Highcharts.chart(chart_id,
         title: { text: 'Currency History' },
         xAxis: { categories: highchart_item['categories'] },
-        yAxis: { title: { text: source } },
+        yAxis: { title: { text: base } },
         series: do ->
             for currency, series of highchart_item.series
               { name: currency, data: series }

--- a/app/service/currency_exchanger.rb
+++ b/app/service/currency_exchanger.rb
@@ -20,9 +20,7 @@ class CurrencyExchanger
   end
 
   def rate_for(currency)
-    (@foreign_rates.find do |entry|
-      entry['target'] == currency || entry['currency'] == currency
-    end || {})['rate']
+    (@foreign_rates.find {|entry| entry['currency'] == currency} || {})['rate']
   end
 
   def inverse_rate
@@ -42,8 +40,7 @@ class CurrencyExchanger
   end
 
   def foreign_currencies
-    @foreign_currencies ||= @foreign_rates.map do |foreign_rate|
-      foreign_rate['target'] || foreign_rate['currency']
-    end
+    @foreign_currencies ||=
+      @foreign_rates.map { |foreign_rate| foreign_rate['currency'] }
   end
 end

--- a/db/migrate/20200405111602_remove_source_from_currencies.rb
+++ b/db/migrate/20200405111602_remove_source_from_currencies.rb
@@ -1,0 +1,5 @@
+class RemoveSourceFromCurrencies < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :currencies, :source, :string
+  end
+end

--- a/db/migrate/20200405111852_remove_target_rates_from_currencies.rb
+++ b/db/migrate/20200405111852_remove_target_rates_from_currencies.rb
@@ -1,0 +1,5 @@
+class RemoveTargetRatesFromCurrencies < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :currencies, :target_rates, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_05_093449) do
+ActiveRecord::Schema.define(version: 2020_04_05_111852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "currencies", force: :cascade do |t|
     t.datetime "published_at"
-    t.string "source"
-    t.json "target_rates"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "base", default: "", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,8 +16,8 @@ from = to - 100.days
   attributes = FactoryBot.attributes_for(:currency,
                                          :with_random_target_rates,
                                          published_at: date)
-  Currency.find_or_create_by(source: attributes[:source],
+  Currency.find_or_create_by(base: attributes[:base],
                              published_at: attributes[:published_at]) do |entry|
-    entry.target_rates = attributes[:target_rates]
+    entry.foreign_rates = attributes[:foreign_rates]
   end
 end

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe CurrencyHelper, type: :helper do
     subject(:available_options) { helper.available_options(currency) }
     let(:currency) do
       FactoryBot.create(:currency,
-                        source: source,
-                        target_rates: [{ 'target': target}])
+                        base: base,
+                        foreign_rates: [{ 'currency': foreign}])
     end
-    let(:source) { 'FOO' }
-    let(:target) { 'BAR' }
+    let(:base) { 'FOO' }
+    let(:foreign) { 'BAR' }
 
     it { is_expected.to eq([['FOO', 'FOO'], ['BAR', 'BAR']]) }
 
-    context 'when source and target are the same' do
-      let(:source) { 'FOO' }
-      let(:target) { source }
+    context 'when base and foreign are the same' do
+      let(:base) { 'FOO' }
+      let(:foreign) { base }
 
       it { is_expected.to eq([['FOO', 'FOO']]) }
     end

--- a/spec/models/currency_spec.rb
+++ b/spec/models/currency_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Currency, type: :model do
     end
   end
 
-  describe '#target_rates' do
-    subject(:target_rates) { currency.target_rates }
+  describe '#foreign_rates' do
+    subject(:foreign_rates) { currency.foreign_rates }
     let(:currency) { described_class.create(attributes) }
 
-    it { is_expected.to eq(attributes[:target_rates]) }
+    it { is_expected.to eq(attributes[:foreign_rates]) }
   end
 end

--- a/spec/service/currency_exchange_spec.rb
+++ b/spec/service/currency_exchange_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe CurrencyExchanger do
   let(:exchanger) { described_class.new(base_currency, foreign_rates) }
   let(:foreign_rates) { [euro_to_dollar, swiss_franc_to_dollar]}
-  let(:euro_to_dollar) { { 'target' => 'EUR', 'rate' => 0.5 } }
-  let(:swiss_franc_to_dollar) { { 'target' => 'CHF', 'rate' => 0.8 } }
+  let(:euro_to_dollar) { { 'currency' => 'EUR', 'rate' => 0.5 } }
+  let(:swiss_franc_to_dollar) { { 'currency' => 'CHF', 'rate' => 0.8 } }
 
   describe '#foreign_rate_for' do
     subject(:foreign_rate_for) { exchanger.foreign_rate_for(foreign_currency) }


### PR DESCRIPTION
### What is good for

Follow up MR for this [improvement](https://github.com/sushie1984/rails-graphql-server/pull/15) fully applying the currency schema refactoring and ultimately dropping `source` and `target_rates` attributes from the model