### PR TITLE
Add grapql mutation 

### DIFF
--- a/app/graphql/input_objects/department_attributes.rb
+++ b/app/graphql/input_objects/department_attributes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module InputObjects
+  class DepartmentAttributes < Types::BaseInputObject
+    description 'Attributes for modifying a department entry'
+    argument :name, String, 'The name of the department', required: true
+    argument :location, String, 'The location of the deparment', required: true
+  end
+end

--- a/app/graphql/input_objects/department_attributes.rb
+++ b/app/graphql/input_objects/department_attributes.rb
@@ -4,6 +4,6 @@ module InputObjects
   class DepartmentAttributes < Types::BaseInputObject
     description 'Attributes for modifying a department entry'
     argument :name, String, 'The name of the department', required: true
-    argument :location, String, 'The location of the deparment', required: true
+    argument :location, String, 'The location of the department', required: true
   end
 end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Mutations
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    # Add your custom classes if you have them:
+    # This is used for generating payload types
+    object_class Types::BaseObject
+    # This is used for return fields on the mutation's payload
+    field_class Types::BaseField
+    # This is used for generating the `input: { ... }` object type
+    input_object_class Types::BaseInputObject
+  end
+end

--- a/app/graphql/mutations/create_department.rb
+++ b/app/graphql/mutations/create_department.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Mutations
+  class CreateDepartment < BaseMutation
+    null true
+
+    argument :attributes, InputObjects::DepartmentAttributes, required: true
+
+    field :department, Types::DepartmentType, null: true
+    field :errors, [String], null: false
+
+    def resolve(attributes:)
+      department = Department.new(attributes.to_h)
+      if department.save
+        { department: department, errors: [] }
+      else
+        { department: nil, errors: department.errors.full_messages }
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,13 +2,6 @@
 
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field,
-          String,
-          null: false,
-          description: 'An example field added by the generator'
-    def test_field
-      'Hello World'
-    end
+    field :create_department, mutation: Mutations::CreateDepartment
   end
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -2,4 +2,6 @@
 
 class Department < ApplicationRecord
   has_and_belongs_to_many :employees
+
+  validates :name, :location, presence: true
 end

--- a/spec/graphql/mutations/create_department_spec.rb
+++ b/spec/graphql/mutations/create_department_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateDepartment do
+  let(:mutation) { described_class.new(object: {}, context: {}, field: {}) }
+
+  describe '#resolve' do
+    subject(:resolve) { mutation.resolve(attributes: attributes) }
+    let(:attributes) { FactoryBot.attributes_for(:department) }
+
+    it 'creates a department' do
+      expect { resolve }
+        .to change { Department.where(attributes).count }.from(0).to(1)
+    end
+
+    it 'responds with created department' do
+      is_expected.to include(department: Department.find_by(attributes))
+    end
+
+    it 'responds with no errors' do
+      is_expected.to include(errors: [])
+    end
+
+    context 'when department cannot be created' do
+      let(:attributes) { { name: nil, location: nil } }
+
+      it 'responds with no created deparment' do
+        is_expected.to include(department: nil)
+      end
+
+      it 'responds with errors' do
+        is_expected.to include(errors: ["Name can't be blank",
+                                        "Location can't be blank"])
+      end
+    end
+  end
+end

--- a/spec/graphql/mutations/create_department_spec.rb
+++ b/spec/graphql/mutations/create_department_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Mutations::CreateDepartment do
     context 'when department cannot be created' do
       let(:attributes) { { name: nil, location: nil } }
 
-      it 'responds with no created deparment' do
+      it 'responds with no created department' do
         is_expected.to include(department: nil)
       end
 


### PR DESCRIPTION
Allows to create `department` via graphql mutation functionality

### Where to start reviewing
[`create_department.rb`](https://github.com/sushie1984/rails-graphql-server/pull/31/files#diff-16877d68c4b1c9342c487b55d51c109d)

### Manual testing
* Start service
* With your favorite tool perform `mutation` queries against the server
* If succeed expect a json response of the created `department`
* If failed expect a json response with the errors informing about why it failed

### References
[Project Ticket](https://github.com/sushie1984/rails-graphql-server/projects/1#card-36543420) 