### PR TITLE
Use more accurate version of graphql gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphql (1.9.12)
+    graphql (1.10.8)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt


### PR DESCRIPTION
Upgrades to graphql gem to version `1.10.8` 

## Manual testing
* Start server
* Perform graphql queries against it
* Expect to behave similiar as before except for one edge case:
  * When querying with an empty input set (aka ` query { departments() { .. } }` it will raise an error

## Resources
* [Issue](https://github.com/sushie1984/rails-graphql-server/projects/1#card-37472540)